### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,11 +3,17 @@
 const path = require("path");
 const express = require("express");
 const dotenv = require("dotenv");
+const RateLimit = require("express-rate-limit");
 
 dotenv.config();
 
 const app = express();
 const port = process.env.PORT || 3001;
+
+const mediaRateLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 const videoBasePath = process.env.VIDEO_BASE_PATH
   ? path.resolve(__dirname, process.env.VIDEO_BASE_PATH)
@@ -25,7 +31,7 @@ if (!videoBasePath || !thumbnailBasePath) {
 
 app.use(express.static(path.resolve(__dirname, "public")));
 
-app.get("/video", (req, res) => {
+app.get("/video", mediaRateLimiter, (req, res) => {
   if (!req.query.video) {
     return res.status(400).send("Video query parameter is required");
   }
@@ -45,7 +51,7 @@ app.get("/video", (req, res) => {
   });
 });
 
-app.get("/thumbnail", (req, res) => {
+app.get("/thumbnail", mediaRateLimiter, (req, res) => {
   if (!req.query.video) {
     return res.status(400).send("Video query parameter is required");
   }

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "dotenv": "^17.4.1",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"


### PR DESCRIPTION
Potential fix for [https://github.com/thomasthaddeus/ReactVideoServer/security/code-scanning/6](https://github.com/thomasthaddeus/ReactVideoServer/security/code-scanning/6)

In general, this should be fixed by introducing a rate-limiting middleware (such as `express-rate-limit`) and applying it to routes that perform expensive operations like file access, especially `/video` and `/thumbnail`. The limiter should be configured with sensible defaults (e.g., a maximum number of requests per IP per time window), and then mounted either globally (`app.use(limiter)`) or specifically on the sensitive routes.

The best minimal fix that doesn’t otherwise change functionality is: require `express-rate-limit`, create a limiter instance (for example, 100 requests per 15 minutes per IP), and apply it to both `/video` and `/thumbnail` routes. To keep changes localized, add the `express-rate-limit` require near the other `require` calls at the top of `server/index.js`, define the limiter right after the `app` and `port` declarations, and then add the limiter as middleware for each route, e.g., `app.get("/thumbnail", thumbnailLimiter, (req, res) => { ... })`. Since we only see this one file, all edits stay within `server/index.js`.

Concretely:
- Add `const RateLimit = require("express-rate-limit");` near the top.
- Define a limiter, e.g.:

  ```js
  const thumbnailLimiter = RateLimit({
    windowMs: 15 * 60 * 1000,
    max: 100,
  });
  ```

  Optionally reuse the same limiter for `/video` as well, which is also file-system heavy.
- Modify the route declarations so they use the limiter: `app.get("/thumbnail", thumbnailLimiter, (req, res) => { ... });` and similarly for `/video`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
