### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -56,9 +56,18 @@ app.get("/thumbnail", mediaRateLimiter, (req, res) => {
     return res.status(400).send("Video query parameter is required");
   }
 
-  const thumbnailPath = path.join(thumbnailBasePath, req.query.video);
+  const requestedThumbnailPath = path.resolve(thumbnailBasePath, req.query.video);
 
-  res.sendFile(thumbnailPath, (err) => {
+  // Ensure the resolved path is within the configured thumbnail base directory
+  const normalizedThumbnailBasePath = path.resolve(thumbnailBasePath) + path.sep;
+  if (
+    requestedThumbnailPath !== path.resolve(thumbnailBasePath) &&
+    !requestedThumbnailPath.startsWith(normalizedThumbnailBasePath)
+  ) {
+    return res.status(403).send("Invalid thumbnail path");
+  }
+
+  res.sendFile(requestedThumbnailPath, (err) => {
     if (err) {
       if (!res.headersSent) {
         res.status(404).send("Thumbnail not found");


### PR DESCRIPTION
Potential fix for [https://github.com/thomasthaddeus/ReactVideoServer/security/code-scanning/4](https://github.com/thomasthaddeus/ReactVideoServer/security/code-scanning/4)

In general, the fix is to ensure that user-controlled path components are normalized and constrained to a known safe root directory before being used to access the filesystem. The safest approach here is to resolve the requested filename relative to `thumbnailBasePath`, normalize it, and then verify that the resulting path is still within `thumbnailBasePath`. If it is not, return a 403 or 400 error instead of calling `res.sendFile`.

The minimal change that preserves existing behavior is: in the `/thumbnail` route, replace the simple `path.join(thumbnailBasePath, req.query.video)` with a secure resolution flow:

1. Resolve the user input relative to `thumbnailBasePath` using `path.resolve(thumbnailBasePath, req.query.video)` (normalizes `..` segments).
2. Optionally, make the path absolute and normalized even further using `path.resolve` (already done in step 1) and compare prefixes in a safe way.
3. Check that the resulting path starts with `thumbnailBasePath` plus a path separator (or is exactly equal), to avoid prefix tricks like `/safe/path2` passing the check for `/safe/path`.
4. If the check fails, respond with 403 and do not call `res.sendFile`.
5. If it passes, call `res.sendFile` with the safe path.

We already have `path` imported at the top of `server/index.js`, so no new imports are required. All changes will be confined to the `/thumbnail` handler (lines 54–71). We do not need extra methods or external libraries for this basic containment check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
