### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
Potential fix for [https://github.com/thomasthaddeus/ReactVideoServer/security/code-scanning/9](https://github.com/thomasthaddeus/ReactVideoServer/security/code-scanning/9)

In general, fix this by adding an explicit `permissions` section either at the top level of the workflow or under the specific job, granting the narrowest required permissions. This documents the workflow’s needs and prevents it from inheriting potentially over-privileged defaults from the repo or organization.

For this particular workflow, the `deploy` job checks out the repository and pushes to the `dist` branch. That requires write access to repository contents via the GITHUB_TOKEN. It does not appear to need any other elevated scopes (like `pull-requests`, `issues`, etc.). The best fix is to add a `permissions` block to the `deploy` job, right under `runs-on: ubuntu-latest`, with `contents: write`. This keeps the permission scope local to this job and avoids affecting other jobs that might be added later. No additional methods, imports, or external definitions are needed; the change is purely in the YAML configuration.

Concretely: edit `.github/workflows/dist.yml` and insert:

```yaml
    permissions:
      contents: write
```

on the line immediately after `runs-on: ubuntu-latest`, keeping indentation consistent with the existing YAML structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
